### PR TITLE
Removed routify transformation of static source dir

### DIFF
--- a/src/lustre/ssg.gleam
+++ b/src/lustre/ssg.gleam
@@ -395,19 +395,19 @@ pub fn add_dynamic_route(
   Config(..config, routes: [route, ..config.routes])
 }
 
-///
+/// Include a static directory from which all files will be copied over into
+/// the temporary build directory before building the site.
 ///
 pub fn add_static_dir(
   config: Config(has_static_routes, NoStaticDir, use_index_routes),
   path: String,
 ) -> Config(has_static_routes, HasStaticDir, use_index_routes) {
   let Config(out_dir, _, static_assets, routes, use_index_routes) = config
-  let static_dir = routify(path)
 
   // We must reconstruct the `Config` entirely instead of using Gleam's spread
   // operator because we need to change the type of the configuration. Specifically,
   // we're adding the `HasStaticDir` type parameter.
-  Config(out_dir, Some(static_dir), static_assets, routes, use_index_routes)
+  Config(out_dir, Some(path), static_assets, routes, use_index_routes)
 }
 
 /// Include a static asset in the generated site. This might be something you


### PR DESCRIPTION
When a `static_dir` is added to the build config, it is only ever used as the source of a `simplifile.copy_directory(path, temp)` call at the beginning of the build process. The provided input path should be considered correctly provided by the user, and not run through the `routify()` transformation to transform it to lowercase and replace whitespace with dashes.

For example, if the static source files reside in a path that happens to contain uppercase letters or whitespace, the build will fail with an error like the following (note the capital "Gleam" in the build directory):

![image](https://github.com/lustre-labs/ssg/assets/965960/ad575e66-5b23-415a-b42e-e52ba97c0ce8)