### PR TITLE
Add attributes for Atom elements

### DIFF
--- a/src/lustre/ssg/atom.gleam
+++ b/src/lustre/ssg/atom.gleam
@@ -1,90 +1,100 @@
 // IMPORTS ---------------------------------------------------------------------
 
-import lustre/attribute.{attribute}
+import lustre/attribute.{type Attribute, attribute}
 import lustre/element.{type Element, element}
 
 // ELEMENTS --------------------------------------------------------------------
 
-pub fn feed(children: List(Element(a))) {
-  element("feed", [attribute("xmlns", "http://www.w3.org/2005/Atom")], children)
+pub fn feed(attrs: List(Attribute(a)), children: List(Element(a))) {
+  element(
+    "feed",
+    [attribute("xmlns", "http://www.w3.org/2005/Atom"), ..attrs],
+    children,
+  )
 }
 
-pub fn entry(children: List(Element(a))) {
-  element("entry", [], children)
+pub fn entry(attrs: List(Attribute(a)), children: List(Element(a))) {
+  element("entry", attrs, children)
 }
 
-pub fn id(uri: String) {
-  element("id", [], [element.text(uri)])
+pub fn id(attrs: List(Attribute(a)), uri: String) {
+  element("id", attrs, [element.text(uri)])
 }
 
-pub fn title(title: String) {
-  element("title", [attribute("type", "html")], [element.text(title)])
+pub fn title(attrs: List(Attribute(a)), title: String) {
+  element("title", [attribute("type", "html"), ..attrs], [element.text(title)])
 }
 
-pub fn updated(iso_timestamp: String) {
-  element("updated", [], [element.text(iso_timestamp)])
+pub fn updated(attrs: List(Attribute(a)), iso_timestamp: String) {
+  element("updated", attrs, [element.text(iso_timestamp)])
 }
 
-pub fn published(iso_timestamp: String) {
-  element("published", [], [element.text(iso_timestamp)])
+pub fn published(attrs: List(Attribute(a)), iso_timestamp: String) {
+  element("published", attrs, [element.text(iso_timestamp)])
 }
 
-pub fn author(children: List(Element(a))) {
-  element("author", [], children)
+pub fn author(attrs: List(Attribute(a)), children: List(Element(a))) {
+  element("author", attrs, children)
 }
 
-pub fn contributor(children: List(Element(a))) {
-  element("contributor", [], children)
+pub fn contributor(attrs: List(Attribute(a)), children: List(Element(a))) {
+  element("contributor", attrs, children)
 }
 
-pub fn source(children: List(Element(a))) {
-  element("source", [], children)
+pub fn source(attrs: List(Attribute(a)), children: List(Element(a))) {
+  element("source", attrs, children)
 }
 
-pub fn link(attributes: List(attribute.Attribute(a))) {
-  element.advanced("", "link", attributes, [], True, False)
+pub fn link(attrs: List(attribute.Attribute(a))) {
+  element.advanced("", "link", attrs, [], True, False)
 }
 
-pub fn name(name: String) {
-  element("name", [], [element.text(name)])
+pub fn name(attrs: List(Attribute(a)), name: String) {
+  element("name", attrs, [element.text(name)])
 }
 
-pub fn email(email: String) {
-  element("email", [], [element.text(email)])
+pub fn email(attrs: List(Attribute(a)), email: String) {
+  element("email", attrs, [element.text(email)])
 }
 
-pub fn uri(uri: String) {
-  element("uri", [], [element.text(uri)])
+pub fn uri(attrs: List(Attribute(a)), uri: String) {
+  element("uri", attrs, [element.text(uri)])
 }
 
-pub fn category(attributes: List(attribute.Attribute(a))) {
-  element.advanced("", "category", attributes, [], True, False)
+pub fn category(attrs: List(Attribute(a))) {
+  element.advanced("", "category", attrs, [], True, False)
 }
 
-pub fn generator(attributes: List(attribute.Attribute(a)), name: String) {
-  element("generator", attributes, [element.text(name)])
+pub fn generator(attrs: List(Attribute(a)), name: String) {
+  element("generator", attrs, [element.text(name)])
 }
 
-pub fn icon(path: String) {
-  element("icon", [], [element.text(path)])
+pub fn icon(attrs: List(Attribute(a)), path: String) {
+  element("icon", attrs, [element.text(path)])
 }
 
-pub fn logo(path: String) {
-  element("logo", [], [element.text(path)])
+pub fn logo(attrs: List(Attribute(a)), path: String) {
+  element("logo", attrs, [element.text(path)])
 }
 
-pub fn rights(rights: String) {
-  element("rights", [], [element.text(rights)])
+pub fn rights(attrs: List(Attribute(a)), rights: String) {
+  element("rights", attrs, [element.text(rights)])
 }
 
-pub fn subtitle(subtitle: String) {
-  element("subtitle", [attribute("type", "html")], [element.text(subtitle)])
+pub fn subtitle(attrs: List(Attribute(a)), subtitle: String) {
+  element("subtitle", [attribute("type", "html"), ..attrs], [
+    element.text(subtitle),
+  ])
 }
 
-pub fn summary(summary: String) {
-  element("summary", [attribute("type", "html")], [element.text(summary)])
+pub fn summary(attrs: List(Attribute(a)), summary: String) {
+  element("summary", [attribute("type", "html"), ..attrs], [
+    element.text(summary),
+  ])
 }
 
-pub fn content(content: String) {
-  element("content", [attribute("type", "html")], [element.text(content)])
+pub fn content(attrs: List(Attribute(a)), content: String) {
+  element("content", [attribute("type", "html"), ..attrs], [
+    element.text(content),
+  ])
 }


### PR DESCRIPTION
This adds attribute support for all Atom elements. This is required for using attributes such as `xml:lang` to denote the language of the whole feed or individual feed items.

Scriptorium has been updated to use this (only on my local machine for now) and I've tested that they work. The API also now echoes that of `lustre/element/html` more closely.