### PR TITLE
fix: correct "src" -> "dev" directory mentioned in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ hydration. If you need those things, you will have to build them yourself!
 $ gleam add lustre_ssg --dev
 ```
 
-2. Create a `build.gleam` file in your project's `src` directory.
+2. Create a `build.gleam` file in your project's `dev` directory.
 
 3. Import `lustre/ssg` and configure your routes:
 


### PR DESCRIPTION
I believe this is an error in the README. 
I'm new to Gleam but it seems like build.gleam is essentially a build script and imports a dev-depencency. 

dev-dependencies are not available to the regular application, which I understand to be in `/src`, instead build script should be placed under `/dev` I believe

Feel free to close this if it's wrong or I am missunderstanding 