### PR TITLE
Correct dependency addition instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ hydration. If you need those things, you will have to build them yourself!
 
 ## Usage
 
-1. Add `lustre_ssg` as a development dependency to your Gleam project:
+1. Add `lustre_ssg` as a dependency to your Gleam project:
 
 ```sh
-$ gleam add lustre_ssg --dev
+$ gleam add lustre_ssg
 ```
 
 2. Create a `build.gleam` file in your project's `src` directory.


### PR DESCRIPTION
Hello!

`lustre_ssg` is directly used by the user's program that builds the static, rather than being used in tests or in some other supplementary way, so it is a regular dependency of the program.

Cheers,
Louis